### PR TITLE
Use multiple names to find ruby in the PATH env var

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -28,6 +28,7 @@ export class Global extends Disposition{
   }
     
   readonly gempath: string = join(process.env.GEM_HOME || '', '/bin/ruby');
+  readonly ruby_path_names = ["ruby", "shims"]
 
   private _node_storage!: NodeStorage;
   get nodeStorage(){
@@ -59,7 +60,7 @@ export class Global extends Disposition{
   get ruby_paths(){
     return _.compact([
       process.env['MY_RUBY_HOME'] ? join(process.env['MY_RUBY_HOME'], 'bin') : '',
-      ...(process.env['PATH']?.split(delimiter).filter(ele => ele.includes('ruby')) || [])
+      ...(process.env['PATH']?.split(delimiter).filter(ele => this.ruby_path_names.some(n => ele.includes(n))) || [])
     ])
   }
 


### PR DESCRIPTION
I use `asdf` to handle my Ruby installation, which means that I don't have anything including the word `ruby` in my PATH environment variable. This results in the extension failing with an error saying that `bundle` cannot be found.

`asdf` adds to the `PATH` environment variable the following path: `/Users/pedrogalan/.asdf/shims`. Here is where the `ruby` and `bundle` binaries live.

So, in order for the function `ruby_paths()` to be able to find the required binaries for those users using `asdf`, I have slightly modified the filter so that it looks, not only for the name `ruby` but also for others (e.g. `shims` and possibly others that might be added to the array in the future).